### PR TITLE
Update SerialTransfer dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ board = teensy31
 lib_deps =
     https://github.com/PaulStoffregen/Servo
     https://github.com/PaulStoffregen/Encoder
-    https://github.com/PowerBroker2/SerialTransfer#3.0.4
+    https://github.com/PowerBroker2/SerialTransfer#3.0.5
     https://github.com/SofaPirate/Chrono
     https://github.com/pololu/vl53l0x-arduino
     https://github.com/adafruit/adafruit_ssd1306


### PR DESCRIPTION
Fixes #26

This shouldn't affect serial comms on the pi, as it is purely a hotfix for a compilation problem in SPITransfer and doesn't touch SerialTransfer at all.