### PR TITLE
Update motor speeds every loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,8 @@ RobotHal hal(robotStatus);
 
 SerialTransfer myTransfer;
 
-Chrono receiveMessage;
-Chrono readSensors;
+Chrono receiveMessageTimeout;
+Chrono sendSensorDataTimeout;
 
 int16_t lightSensors[4];
 
@@ -95,7 +95,7 @@ void processMessage(SerialTransfer &transfer) {
             // reset the missed motor mdessage count
             robotStatus.resetMissedMotorCount();
             // We received a valid motor command, so reset the timer
-            receiveMessage.restart();
+            receiveMessageTimeout.restart();
     }
 }
 
@@ -236,9 +236,9 @@ void loop() {
 
     // if the message sending timeout has passed then increment the missed count
     // and reset
-    if (receiveMessage.hasPassed(20)) {
+    if (receiveMessageTimeout.hasPassed(20)) {
         robotStatus.incrementMissedMotorCount();
-        receiveMessage.restart();
+        receiveMessageTimeout.restart();
     }
 
     if (robotStatus.batteryIsLow() || robotStatus.motorMessageCommsDown()) {
@@ -254,8 +254,8 @@ void loop() {
         screen.showScreen();
     }
 
-    if (readSensors.hasPassed(10)) {
-        readSensors.restart();
+    if (sendSensorDataTimeout.hasPassed(10)) {
+        sendSensorDataTimeout.restart();
         /// Read Encoder counts
         for (u_int8_t n = 0; n < NUM_ENCODERS; n++) {
             robotStatus.sensors.encoders.previous[n] = robotStatus.sensors.encoders.current[n];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,6 +225,10 @@ void setup() {
 }
 
 void loop() {
+    // update sensor readings
+    // currently only TOF and IMU, but will also include encoders as part of issue #52
+    hal.updateSensors();
+
     // Is there an incoming message available?
     if (myTransfer.available()) {
         processMessage(myTransfer);
@@ -252,20 +256,11 @@ void loop() {
 
     if (readSensors.hasPassed(10)) {
         readSensors.restart();
-
-        // update TOF sensor readings
-        hal.updateTOFSensors();
-
         /// Read Encoder counts
         for (u_int8_t n = 0; n < NUM_ENCODERS; n++) {
             robotStatus.sensors.encoders.previous[n] = robotStatus.sensors.encoders.current[n];
             robotStatus.sensors.encoders.current[n] = encoders[n].read();
         }
-
-        // Update orientation status from IMU
-        sensors_event_t orientationData;
-        bno.getEvent(&orientationData, Adafruit_BNO055::VECTOR_EULER);
-        robotStatus.updateOrientation(orientationData);
 
         uint16_t payloadSize = 0;
 

--- a/src/robot_hal.cpp
+++ b/src/robot_hal.cpp
@@ -289,3 +289,14 @@ void RobotHal::doI2CScan() {
         _status.activation.i2c[addr] = (wire->endTransmission() == 0);
     }
 }
+
+void RobotHal::updateSensors() {
+    updateTOFSensors();
+    updateIMU();
+}
+
+void RobotHal::updateIMU() {
+    sensors_event_t orientationData;
+    bno.getEvent(&orientationData, Adafruit_BNO055::VECTOR_EULER);
+    _status.updateOrientation(orientationData);
+}

--- a/src/robot_hal.h
+++ b/src/robot_hal.h
@@ -32,6 +32,9 @@ class RobotHal {
     bool restoreCalibrationData();
     void saveCalibrationData();
     bool getIMUEvent();
+    void updateIMU();
+
+    void updateSensors();
 
     void doI2CScan();
 


### PR DESCRIPTION
Instead of only forcing a tick of the PID every time a motor message is
received, instead update the motor speeds every loop, using the
currently requested motor speeds. In order to do so, adjust
the status object to track the currently requested speed.