### PR TITLE
Update motor speeds every loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ void processMessage(SerialTransfer &transfer) {
         default:
             Speeds requestedMotorSpeeds;
             transfer.rxObj(requestedMotorSpeeds, recSize);
-            hal.setMotorSpeeds(requestedMotorSpeeds);
+            hal.setRequestedMotorSpeeds(requestedMotorSpeeds);
             // reset the missed motor mdessage count
             robotStatus.resetMissedMotorCount();
             // We received a valid motor command, so reset the timer
@@ -291,4 +291,7 @@ void loop() {
         // Send data
         myTransfer.sendData(payloadSize);
     }
+
+    // Update motor speeds
+    hal.updateMotorSpeeds();
 }

--- a/src/robot_hal.h
+++ b/src/robot_hal.h
@@ -20,7 +20,8 @@ class RobotHal {
 
     bool initialiseMotors();
     void stopMotors();
-    void setMotorSpeeds(Speeds requestedMotorSpeeds);
+    void setRequestedMotorSpeeds(Speeds requestedMotorSpeeds);
+    void updateMotorSpeeds();
     Speeds getWheelTravel();
     float getDistanceTravelled();
 

--- a/src/status.h
+++ b/src/status.h
@@ -10,7 +10,12 @@ class Status {
    public:
     ActivationStatus activation;
     SensorData sensors;
-    Speeds speed;
+    struct
+    {
+        Speeds currentSpeed;
+        Speeds requestedSpeed;
+        float averageSpeed;
+    } speeds;
     float averageSpeed;
     Pose pose;
     uint32_t missedMotorMessageCount = 0;


### PR DESCRIPTION
Instead of only forcing a tick of the PID every time a motor message is
received, instead update the motor speeds every loop, using the
currently requested motor speeds. In order to do so, adjust
the status object to track the currently requested speed
Fixes #46